### PR TITLE
RenderItem searches through the actor registry 

### DIFF
--- a/scripts/rollHandlers/lancer/lancer-base.js
+++ b/scripts/rollHandlers/lancer/lancer-base.js
@@ -7,8 +7,7 @@ export class RollHandlerBaseLancer extends RollHandler {
 
   /** @override */
   getActor(actorId) {
-    return canvas.tokens.placeables.find((t) => t.data.actorId === actorId)
-      ?.actor;
+    return game.actors.get(actorId);
   }
 
   /** @override */


### PR DESCRIPTION
so it is not necessary for the pilot to be on the field for right click to get pilot talents on mech actors