### PR TITLE
Added Support for 4th edition D&D (DnD4E)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -261,6 +261,16 @@
         "rest": "Rest",
         "specialattacks": "Special Attacks"
       },
+      "dnd4e": {
+        "hideUsedPowers": {
+          "hint": "If enabled, abilities that are unavailable will be hidden (except for recharge powers that will roll to recharge)",
+          "name": "Hide used powers"
+        },
+        "forcePowerColours": {
+          "hint": "If enabled, power buttons are coloured by their use (at-will, daily, etc...) - optional as looks a bit ugly",
+          "name": "Colour Powers By Use Type"
+        }
+      },
       "dnd5e": {
         "abbreviateSkills": {
           "hint": "If enabled, skills and abilities will use a three-character abbreviation.",

--- a/module.json
+++ b/module.json
@@ -91,7 +91,8 @@
     "ds4",
     "coc",
     "cof",
-    "forbidden-lands"
+    "forbidden-lands",
+	"dnd4e"
   ],
   "dependencies": [],
   "socket": false,

--- a/scripts/actions/dnd4e/dnd4e-actions.js
+++ b/scripts/actions/dnd4e/dnd4e-actions.js
@@ -1,0 +1,668 @@
+import { ActionHandler } from "../actionHandler.js";
+import * as settings from "../../settings.js";
+import { Logger } from "../../logger.js";
+
+export class ActionHandlerDnD4e extends ActionHandler {
+    constructor(filterManager, categoryManager) {
+        super(filterManager, categoryManager);
+    }
+
+    /** @override */
+    doBuildActionList(token, multipleTokens) {
+        if (token) {
+            return this._buildSingleTokenList(token);
+        } else if (multipleTokens) {
+            return this._buildMultipleTokenList();
+        }
+        return this.initializeEmptyActionList();
+    }
+
+    async _buildSingleTokenList(token) {
+        const list = this.initializeEmptyActionList();
+        list.tokenId = token?.id;
+        list.actorId = token?.actor?.id;
+        if (!list.tokenId || !list.actorId) {
+            return list;
+        }
+
+        if (settings.get("showHudTitle")) {
+            list.hudTitle = token.data?.name;
+        }
+
+        const cats = await this._buildCategories(token);
+        cats
+            .flat()
+            .filter((c) => c)
+            .forEach((c) => {
+                this._combineCategoryWithList(list, c.name, c);
+            });
+
+        return list;
+    }
+
+    _buildCategories(token) {
+        return [
+            this._buildAbilitiesCategory(token),
+            this._buildSkillsCategory(token),
+            // this._buildEffectsCategory(token),
+            this._buildPowersCategory(token),
+            this._buildFeaturesCategory(token),
+            this._buildConditionsCategory(token),
+            this._buildUtilityCategory(token),
+        ];
+    }
+
+    _buildAbilitiesCategory(token) {
+        const actor = token.actor;
+        const abilities = actor.data.data.abilities;
+
+        return this._getAbilityList(
+            token.id,
+            abilities,
+            "abilities",
+            this.i18n("tokenactionhud.abilities"),
+            "ability"
+        );
+    }
+
+    _buildMultipleTokenList() {
+        const list = this.initializeEmptyActionList();
+        list.tokenId = "multi";
+        list.actorId = "multi";
+
+        const allowedTypes = ["Player Character","NPC"];
+        let actors = canvas.tokens.controlled
+            .map((t) => t.actor)
+            .filter((a) => allowedTypes.includes(a.data.type));
+
+        const tokenId = list.tokenId;
+
+        this._addMultiSkills(list, tokenId);
+
+        let abilitiesTitle = this.i18n("tokenactionhud.abilities");
+        this._addMultiAbilities(
+            list,
+            tokenId,
+            "abilities",
+            abilitiesTitle,
+            "ability"
+        );
+
+        if (settings.get("showConditionsCategory"))
+            this._addMultiConditions(list, tokenId);
+
+        this._addMultiUtilities(list, tokenId, actors);
+
+        return list;
+    }
+
+    /** POWERs **/
+    _buildFeaturesCategory(token) {
+        const actor = token.actor;
+        const tokenId = token.id;
+
+        let result = this.initializeEmptyCategory("Features");
+        result.name = this.i18n("DND4EBETA.Features");
+        const features = {
+            raceFeats: { label: "DND4EBETA.FeatRace", items: [], dataset: {type: "raceFeats"} },
+            classFeats: { label: "DND4EBETA.FeatClass", items: [], dataset: {type: "classFeats"} },
+            pathFeats: { label: "DND4EBETA.FeatPath", items: [], dataset: {type: "pathFeats"} },
+            destinyFeats: { label: "DND4EBETA.FeatDestiny", items: [], dataset: {type: "destinyFeats"} },
+            feat: { label: "DND4EBETA.FeatLevel", items: [], dataset: {type: "feat"} },
+            ritual: { label: "DND4EBETA.FeatRitual", items: [], dataset: {type: "ritual"} }
+        };
+
+        actor.data.items.forEach((item) => {
+            if (Object.keys(features).includes(item.data.type)) {
+                features[item.data.type].items.push(item)
+            }
+        })
+
+        Object.entries(features).map((e) => {
+            const subCat = this._buildFeatureSubCategory(actor, e[1].items, tokenId)
+            this._combineSubcategoryWithCategory(result, this.i18n(e[1].label), subCat);
+        });
+
+        return result;
+    }
+
+    _buildFeatureSubCategory(actor, features, tokenId) {
+        const macroType = "feature"
+        const result = this.initializeEmptySubcategory();
+        features.forEach((item) => {
+            const encodedValue = [macroType, tokenId, item.id].join(this.delimiter);
+            const action = {
+                name: item.data.name,
+                id: item.id,
+                encodedValue: encodedValue,
+                img: this._getImage(item)
+            };
+            result.actions.push(action)
+        })
+        return result;
+    }
+
+    /** @private */
+    _buildPowersCategory(token) {
+        const actor = token.actor;
+        const tokenId = token.id;
+
+        let allPowers = actor.data.items.filter((item) => item.data.type === "power")
+
+        let result = this.initializeEmptyCategory("Powers");
+        result.name = this.i18n("DND4EBETA.Powers");
+
+        const goupings = actor.sheet._generatePowerGroups()
+        const groupType = this._getDocumentData(actor).powerGroupTypes
+        let groupField = "useType"
+
+        switch (groupType) {
+            case "action" : groupField = "actionType"
+                break;
+            case "type" : groupField = "powerType"
+                break;
+            default: break;
+        }
+
+        Object.entries(goupings).map((e) => {
+            const subCat = this._buildPowerSubCategory(actor, allPowers, e[1].dataset.type, tokenId, groupField)
+            this._combineSubcategoryWithCategory(result, this.i18n(e[1].label), subCat);
+        });
+
+        return result;
+    }
+
+    _buildPowerSubCategory(actor, powerList, powerType, tokenId, groupField) {
+        const macroType = "power"
+        const result = this.initializeEmptySubcategory();
+        let powers = powerList.filter((power) => this._getDocumentData(power)[groupField] === powerType)
+
+        if(settings.get("hideUsedPowers")) {
+            powers = powers.filter((power) => {
+                actor.sheet._checkPowerAvailable(power.data)
+                const data = this._getDocumentData(power)
+                return data.useType === "recharge" || !data.notAvailable
+            })
+        }
+
+        const colour = settings.get("forcePowerColours")
+        powers.forEach((item) => {
+                const encodedValue = [macroType, tokenId, item.id].join(this.delimiter);
+                const action = {
+                    name: item.data.name,
+                    id: item.id,
+                    encodedValue: encodedValue,
+                    img: this._getImage(item)
+                };
+                if (colour) {
+                    action.cssClass = `force-ability-usage--${this._getDocumentData(item).useType}`
+                }
+                result.actions.push(action)
+            })
+        return result;
+    }
+
+    /** @private */
+    _buildSkillsCategory(token) {
+        const actor = token.actor;
+        if (actor.data.type === "vehicle") return;
+
+        const skills = actor.data.data.skills;
+
+        let result = this.initializeEmptyCategory("skills");
+        result.name = this.i18n("tokenactionhud.skills");
+        let macroType = "skill";
+
+        let abbr = settings.get("abbreviateSkills");
+
+        let skillsActions = Object.entries(skills)
+            .map((e) => {
+                try {
+                    let skillId = e[0];
+                    let name = abbr ? skillId : game.dnd4eBeta.config.skills[skillId];
+                    name = name.charAt(0).toUpperCase() + name.slice(1);
+                    let encodedValue = [macroType, token.id, e[0]].join(this.delimiter);
+                    let icon = this._getProficiencyIcon(skills[skillId].value);
+                    return {
+                        name: name,
+                        id: e[0],
+                        encodedValue: encodedValue,
+                        icon: icon,
+                    };
+                } catch (error) {
+                    Logger.error(e);
+                    return null;
+                }
+            })
+            .filter((s) => !!s);
+        let skillsCategory = this.initializeEmptySubcategory();
+        skillsCategory.actions = skillsActions;
+
+        let skillsTitle = this.i18n("tokenactionhud.skills");
+        this._combineSubcategoryWithCategory(result, skillsTitle, skillsCategory);
+
+        return result;
+    }
+
+    _addMultiSkills(list, tokenId) {
+        let result = this.initializeEmptyCategory("skills");
+        let macroType = "skill";
+
+        let abbr = settings.get("abbreviateSkills");
+
+        let skillsActions = Object.entries(game.dnd4eBeta.config.skills).map((e) => {
+            let name = abbr ? e[0] : e[1];
+            name = name.charAt(0).toUpperCase() + name.slice(1);
+            let encodedValue = [macroType, tokenId, e[0]].join(this.delimiter);
+            return { name: name, id: e[0], encodedValue: encodedValue };
+        });
+        let skillsCategory = this.initializeEmptySubcategory();
+        skillsCategory.actions = skillsActions;
+
+        let skillsTitle = this.i18n("tokenactionhud.skills");
+        this._combineSubcategoryWithCategory(result, skillsTitle, skillsCategory);
+        this._combineCategoryWithList(list, skillsTitle, result, true);
+    }
+
+    /** @private */
+    _getAbilityList(tokenId, abilities, categoryId, categoryName, macroType) {
+        let result = this.initializeEmptyCategory(categoryId);
+        result.name = categoryName;
+
+        let abbr = settings.get("abbreviateSkills");
+
+        let actions = Object.entries(game.dnd4eBeta.config.abilities).map((e) => {
+            if (abilities[e[0]].value === 0) return;
+
+            let name = abbr ? e[0] : e[1];
+            name = name.charAt(0).toUpperCase() + name.slice(1);
+            let encodedValue = [macroType, tokenId, e[0]].join(this.delimiter);
+            let icon;
+            if (categoryId === "checks") icon = "";
+            else icon = this._getProficiencyIcon(abilities[e[0]].proficient);
+
+            return { name: name, id: e[0], encodedValue: encodedValue, icon: icon };
+        });
+        let abilityCategory = this.initializeEmptySubcategory();
+        abilityCategory.actions = actions.filter((a) => !!a);
+
+        this._combineSubcategoryWithCategory(result, categoryName, abilityCategory);
+
+        return result;
+    }
+
+    _addMultiAbilities(list, tokenId, categoryId, categoryName, macroType) {
+        let cat = this.initializeEmptyCategory(categoryId);
+
+        let abbr = settings.get("abbreviateSkills");
+
+        let actions = Object.entries(game.dnd4eBeta.config.abilities).map((e) => {
+            let name = abbr ? e[0] : e[1];
+            name = name.charAt(0).toUpperCase() + name.slice(1);
+            let encodedValue = [macroType, tokenId, e[0]].join(this.delimiter);
+
+            return { name: name, id: e[0], encodedValue: encodedValue };
+        });
+        let abilityCategory = this.initializeEmptySubcategory();
+        abilityCategory.actions = actions;
+
+        this._combineSubcategoryWithCategory(cat, categoryName, abilityCategory);
+        this._combineCategoryWithList(list, categoryName, cat, true);
+    }
+
+    /** @private */
+    _buildUtilityCategory(token) {
+        const actor = token.actor;
+
+        let result = this.initializeEmptyCategory("utility");
+        result.name = this.i18n("tokenactionhud.utility");
+        let macroType = "utility";
+
+        let utility = this.initializeEmptySubcategory();
+
+        this._addIntiativeSubcategory(macroType, result, token.id);
+        let healDialogValue = [macroType, token.id, "healDialog"].join(
+            this.delimiter
+        );
+        utility.actions.push({
+            id: "heal",
+            encodedValue: healDialogValue,
+            name: this.i18n("DND4EBETA.Healing"),
+        });
+
+        let saveValue = [macroType, token.id, "save"].join(
+            this.delimiter
+        );
+        utility.actions.push({
+            id: "save",
+            encodedValue: saveValue,
+            name: this.i18n("DND4EBETA.SavingThrow"),
+        });
+        let saveDialogValue = [macroType, token.id, "saveDialog"].join(
+            this.delimiter
+        );
+        utility.actions.push({
+            id: "saveDialog",
+            encodedValue: saveDialogValue,
+            name: this.i18n("Show Save Dialog"),
+        });
+
+        this._combineSubcategoryWithCategory(
+            result,
+            this.i18n("tokenactionhud.utility"),
+            utility
+        );
+
+        return result;
+    }
+
+    /** @private */
+    _buildEffectsCategory(token) {
+        let result = this.initializeEmptyCategory("effects");
+        result.name = this.i18n("tokenactionhud.effects");
+        this._addEffectsSubcategories(token.actor, token.id, result);
+        return result;
+    }
+
+    /** @private */
+    _buildConditionsCategory(token) {
+        if (!settings.get("showConditionsCategory")) return;
+        let result = this.initializeEmptyCategory("conditions");
+        result.name = this.i18n("tokenactionhud.conditions");
+        this._addConditionsSubcategory(token.actor, token.id, result);
+        return result;
+    }
+
+    /** @private */
+    _addEffectsSubcategories(actor, tokenId, category) {
+        const macroType = "effect";
+
+        const effects =
+            "find" in actor.effects.entries ? actor.effects.entries : actor.effects;
+
+        let tempCategory = this.initializeEmptySubcategory();
+        let passiveCategory = this.initializeEmptySubcategory();
+
+        effects.forEach((e) => {
+            const effectData = this._getDocumentData(e);
+            const name = effectData.label;
+            const encodedValue = [macroType, tokenId, e.id].join(this.delimiter);
+            const cssClass = effectData.disabled ? "" : "active";
+            const image = effectData.icon;
+            let action = {
+                name: name,
+                id: e.id,
+                encodedValue: encodedValue,
+                img: image,
+                cssClass: cssClass,
+            };
+
+            e.isTemporary
+                ? tempCategory.actions.push(action)
+                : passiveCategory.actions.push(action);
+        });
+
+        this._combineSubcategoryWithCategory(
+            category,
+            this.i18n("tokenactionhud.temporary"),
+            tempCategory
+        );
+        this._combineSubcategoryWithCategory(
+            category,
+            this.i18n("tokenactionhud.passive"),
+            passiveCategory
+        );
+    }
+
+    /** @private */
+    _addMultiConditions(list, tokenId) {
+        const category = this.initializeEmptyCategory("conditions");
+        const macroType = "condition";
+
+        const availableConditions = game.dnd4eBeta.config.statusEffect.filter(
+            (condition) => condition.id !== ""
+        );
+        const actors = canvas.tokens.controlled
+            .filter((t) => !!t.actor)
+            .map((t) => t.actor);
+
+        if (!availableConditions) return;
+
+        let conditions = this.initializeEmptySubcategory();
+
+        availableConditions.forEach((c) => {
+            const name = this.i18n(c.label);
+            const encodedValue = [macroType, tokenId, c.id].join(this.delimiter);
+            const cssClass = actors.every((actor) => {
+                const effects =
+                    "some" in actor.effects.entries
+                        ? actor.effects.entries
+                        : actor.effects;
+                effects.some((e) => e.data.flags.core?.statusId === c.id);
+            })
+                ? "active"
+                : "";
+            const image = c.icon;
+            const action = {
+                name: name,
+                id: c.id,
+                encodedValue: encodedValue,
+                img: image,
+                cssClass: cssClass,
+            };
+
+            conditions.actions.push(action);
+        });
+
+        const conName = this.i18n("tokenactionhud.conditions");
+        this._combineSubcategoryWithCategory(category, conName, conditions);
+        this._combineCategoryWithList(list, conName, category);
+    }
+
+    /** @private */
+    _addConditionsSubcategory(actor, tokenId, category) {
+        const macroType = "condition";
+
+        const availableConditions = game.dnd4eBeta.config.statusEffect.filter(
+            (condition) => condition.id !== ""
+        );
+
+        if (!availableConditions) return;
+
+        let conditions = this.initializeEmptySubcategory();
+
+        availableConditions.forEach((c) => {
+            const name = this.i18n(c.label);
+            const encodedValue = [macroType, tokenId, c.id].join(this.delimiter);
+            const effects =
+                "some" in actor.effects.entries ? actor.effects.entries : actor.effects;
+            const cssClass = effects.some((e) => e.data.flags.core?.statusId === c.id)
+                ? "active"
+                : "";
+            const image = c.icon;
+            const action = {
+                name: name,
+                id: c.id,
+                encodedValue: encodedValue,
+                img: image,
+                cssClass: cssClass,
+            };
+
+            conditions.actions.push(action);
+        });
+
+        this._combineSubcategoryWithCategory(
+            category,
+            this.i18n("tokenactionhud.conditions"),
+            conditions
+        );
+    }
+
+    /** @private */
+    _addIntiativeSubcategory(macroType, category, tokenId) {
+        const combat = game.combat;
+        let combatant, currentInitiative;
+        if (combat) {
+            combatant = combat.combatants.find((c) => c.tokenId === tokenId);
+            currentInitiative = combatant?.initiative;
+        }
+
+        let initiative = this.initializeEmptySubcategory();
+
+        let initiativeValue = [macroType, tokenId, "initiative"].join(
+            this.delimiter
+        );
+        let initiativeName = `${this.i18n("tokenactionhud.rollInitiative")}`;
+
+        let initiativeAction = {
+            id: "rollInitiative",
+            encodedValue: initiativeValue,
+            name: initiativeName,
+        };
+
+        if (currentInitiative) initiativeAction.info1 = currentInitiative;
+        initiativeAction.cssClass = currentInitiative ? "active" : "";
+
+        initiative.actions.push(initiativeAction);
+
+        this._combineSubcategoryWithCategory(
+            category,
+            this.i18n("tokenactionhud.initiative"),
+            initiative
+        );
+    }
+
+    /** @private */
+    _addMultiIntiativeSubcategory(macroType, tokenId, category) {
+        const combat = game.combat;
+
+        let initiative = this.initializeEmptySubcategory();
+
+        let initiativeValue = [macroType, tokenId, "initiative"].join(
+            this.delimiter
+        );
+        let initiativeName = `${this.i18n("tokenactionhud.rollInitiative")}`;
+
+        let initiativeAction = {
+            id: "rollInitiative",
+            encodedValue: initiativeValue,
+            name: initiativeName,
+        };
+
+        let isActive;
+        if (combat) {
+            let tokenIds = canvas.tokens.controlled.map((t) => t.id);
+            let tokenCombatants = tokenIds.map((id) =>
+                combat.combatants.find((c) => c.tokenId === id)
+            );
+            isActive = tokenCombatants.every((c) => !!c?.initiative);
+        }
+
+        initiativeAction.cssClass = isActive ? "active" : "";
+
+        initiative.actions.push(initiativeAction);
+
+        this._combineSubcategoryWithCategory(
+            category,
+            this.i18n("tokenactionhud.initiative"),
+            initiative
+        );
+    }
+
+    /** @private */
+    _addMultiUtilities(list, tokenId, actors) {
+        let category = this.initializeEmptyCategory("utility");
+        let macroType = "utility";
+
+        this._addMultiIntiativeSubcategory(macroType, tokenId, category);
+
+        let rests = this.initializeEmptySubcategory();
+        let utility = this.initializeEmptySubcategory();
+
+        if (actors.every((a) => a.data.type === "character")) {
+            let shortRestValue = [macroType, tokenId, "shortRest"].join(
+                this.delimiter
+            );
+            rests.actions.push({
+                id: "shortRest",
+                encodedValue: shortRestValue,
+                name: this.i18n("tokenactionhud.shortRest"),
+            });
+            let longRestValue = [macroType, tokenId, "longRest"].join(this.delimiter);
+            rests.actions.push({
+                id: "longRest",
+                encodedValue: longRestValue,
+                name: this.i18n("tokenactionhud.longRest"),
+            });
+
+            let inspirationValue = [macroType, tokenId, "inspiration"].join(
+                this.delimiter
+            );
+            let inspirationAction = {
+                id: "inspiration",
+                encodedValue: inspirationValue,
+                name: this.i18n("tokenactionhud.inspiration"),
+            };
+            inspirationAction.cssClass = actors.every(
+                (a) => a.data.data.attributes?.inspiration
+            )
+                ? "active"
+                : "";
+            utility.actions.push(inspirationAction);
+        }
+
+        this._combineSubcategoryWithCategory(
+            category,
+            this.i18n("tokenactionhud.rests"),
+            rests
+        );
+        this._combineSubcategoryWithCategory(
+            category,
+            this.i18n("tokenactionhud.utility"),
+            utility
+        );
+        this._combineCategoryWithList(
+            list,
+            this.i18n("tokenactionhud.utility"),
+            category
+        );
+    }
+
+    _getImage(item) {
+        let result = "";
+        if (settings.get("showIcons")) result = item.data.img ?? "";
+
+        return !result?.includes("icons/svg/mystery-man.svg") ? result : "";
+    }
+
+    _filterExpendedItems(items) {
+        if (settings.get("showEmptyItems")) return items;
+
+        return items.filter((i) => {
+            const iData = this._getDocumentData(i);
+            let uses = iData.uses;
+            // Assume something with no uses is unlimited in its use.
+            if (!uses) return true;
+
+            // if it has a max but value is 0, don't return.
+            if (uses.max > 0 && !uses.value) return false;
+
+            return true;
+        });
+    }
+
+    /** @private */
+    _getProficiencyIcon(level) {
+        const icons = {
+            0: "",
+            0.5: '<i class="fas fa-adjust"></i>',
+            5: '<i class="fas fa-check"></i>',
+            8: '<i class="fas fa-check-double"></i>',
+        };
+        return icons[level];
+    }
+
+    _getDocumentData(entity) {
+        return entity.data.data ?? entity.data;
+    }
+}

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -39,6 +39,7 @@ Hooks.on("init", () => {
     "coc": "coc",
     "cof": "cof",
     "forbidden-lands": "forbidden-lands",
+    "dnd4e": "dnd4e"
     /* put all the SystemManagers that are included directly in TAH here */
   }
   Hooks.call('preCreateTAHSystemManager', systemManagers); // this allows systems / modules to react to the hook and inject their own SystemManager

--- a/scripts/managers/dnd4e.js
+++ b/scripts/managers/dnd4e.js
@@ -1,0 +1,33 @@
+import { SystemManager } from "./manager.js";
+import {ActionHandlerDnD4e as ActionHandler} from "../actions/dnd4e/dnd4e-actions.js";
+import {RollHandlerBaseDnD4e as Core} from "../rollHandlers/dnd4e/dnd4e-base.js";
+import * as settings from "../settings/dnd4e-settings.js";
+
+export class DnD4eSystemManager extends SystemManager {
+  constructor(appName) {
+    super(appName);
+  }
+
+  /** @override */
+  doGetActionHandler(filterManager, categoryManager) {
+    let actionHandler = new ActionHandler(filterManager, categoryManager);
+    return actionHandler;
+  }
+
+  /** @override */
+  getAvailableRollHandlers() {
+    let choices = { core: "Core dnd4e" };
+
+    return choices;
+  }
+
+  /** @override */
+  doGetRollHandler(handlerId) {
+    return new Core();
+  }
+
+  /** @override */
+  doRegisterSettings(appName, updateFunc) {
+    settings.register(appName, updateFunc);
+  }
+}

--- a/scripts/managers/systemManagerFactory.js
+++ b/scripts/managers/systemManagerFactory.js
@@ -21,6 +21,7 @@ import { TagmarSystemManager } from "./tagmar.js";
 import { Ds4SystemManager } from "./ds4.js";
 import { CoSystemManager } from "./co.js";
 import { ForbiddenLandsSystemManager } from './forbiddenlands.js'
+import { DnD4eSystemManager } from './dnd4e.js'
 
 export class SystemManagerFactory {
   static create(system, appName) {
@@ -75,6 +76,8 @@ export class SystemManagerFactory {
         return new CoSystemManager(appName);
       case 'forbidden-lands':
         return new ForbiddenLandsSystemManager(appName);
+      case 'dnd4e':
+        return new DnD4eSystemManager(appName);
     }
   }
 }

--- a/scripts/rollHandlers/dnd4e/dnd4e-base.js
+++ b/scripts/rollHandlers/dnd4e/dnd4e-base.js
@@ -1,0 +1,189 @@
+import { RollHandler } from "../rollHandler.js";
+import * as settings from "../../settings.js";
+
+export class RollHandlerBaseDnD4e extends RollHandler {
+  constructor() {
+    super();
+  }
+
+  emptyEvent = {
+    preventDefault : function() {
+    }
+  }
+
+  /** @override */
+  async doHandleActionEvent(event, encodedValue) {
+    let payload = encodedValue.split("|");
+
+    if (payload.length !== 3) {
+      super.throwInvalidValueErr();
+    }
+
+    let macroType = payload[0];
+    let tokenId = payload[1];
+    let actionId = payload[2];
+
+    if (tokenId === "multi") {
+      for (let t of canvas.tokens.controlled) {
+        let idToken = t.id;
+        await this._handleMacros(event, macroType, idToken, actionId);
+      }
+    } else {
+      await this._handleMacros(event, macroType, tokenId, actionId);
+    }
+  }
+
+  async _handleMacros(event, macroType, tokenId, actionId) {
+    switch (macroType) {
+      case "ability":
+        this.rollAbilityMacro(event, tokenId, actionId);
+        break;
+      case "skill":
+        this.rollSkillMacro(event, tokenId, actionId);
+        break;
+      case "feature":
+        if (this.isRenderItem()) this.doRenderItem(tokenId, actionId);
+        else this.rollItemMacro(event, tokenId, actionId);
+        break;
+      case "power":
+        if (this.isRenderItem()) this.doRenderItem(tokenId, actionId);
+        else this.rollPowerMacro(event, tokenId, actionId);
+        break;
+      case "utility":
+        await this.performUtilityMacro(event, tokenId, actionId);
+        break;
+      case "effect":
+        await this.toggleEffect(event, tokenId, actionId);
+        break;
+      case "condition":
+        await this.toggleCondition(event, tokenId, actionId);
+      default:
+        break;
+    }
+  }
+
+  rollAbilityMacro(event, tokenId, checkId) {
+    const actor = super.getActor(tokenId);
+    actor.rollAbility(checkId, { event: event });
+  }
+
+  rollSkillMacro(event, tokenId, checkId) {
+    const actor = super.getActor(tokenId);
+    actor.rollSkill(checkId, { event: event });
+  }
+
+  rollItemMacro(event, tokenId, itemId) {
+    let actor = super.getActor(tokenId);
+    let item = super.getItem(actor, itemId);
+    return item.roll()
+  }
+
+  rollPowerMacro(event, tokenId, itemId) {
+    let actor = super.getActor(tokenId);
+    let item = super.getItem(actor, itemId);
+
+    if (this.needsRecharge(actor, item)) {
+      const event = Object.assign({}, this.emptyEvent)
+      event.currentTarget = { closest : (str) => {return {dataset : { itemId : itemId}}} };
+      actor.sheet._onItemRecharge(event)
+      return;
+    }
+
+    return actor.usePower(item)
+  }
+
+  needsRecharge(actor, item) {
+    const itemData = this._getDocumentData(item);
+    return (
+        itemData.useType === "recharge" && itemData.notAvailable
+    );
+  }
+
+  async performUtilityMacro(event, tokenId, actionId) {
+    let actor = super.getActor(tokenId);
+    let token = super.getToken(tokenId);
+
+
+    switch (actionId) {
+      case "toggleCombat":
+        token.toggleCombat();
+        Hooks.callAll("forceUpdateTokenActionHUD");
+        break;
+      case "toggleVisibility":
+        token.toggleVisibility();
+        break;
+      case "saveDialog":
+        actor.sheet._onSavingThrow(this.emptyEvent)
+        break;
+      case "save":
+        game.dnd4eBeta.quickSave(actor)
+        break;
+      case "healDialog":
+        actor.sheet._onHealMenuDialog(this.emptyEvent)
+        break;
+      case "initiative":
+        await this.performInitiativeMacro(tokenId);
+        break;
+    }
+  }
+
+  async performInitiativeMacro(tokenId) {
+    let actor = super.getActor(tokenId);
+
+    await actor.rollInitiative({ createCombatants: true });
+
+    Hooks.callAll("forceUpdateTokenActionHUD");
+  }
+
+  async toggleEffect(event, tokenId, effectId) {
+    const actor = super.getActor(tokenId);
+    const effects =
+      "find" in actor.effects.entries ? actor.effects.entries : actor.effects;
+    const effect = effects.find((e) => e.id === effectId);
+
+    if (!effect) return;
+
+    const statusId = effect.data.flags.core?.statusId;
+    if (statusId) {
+      await this.toggleCondition(event, tokenId, statusId);
+      return;
+    }
+
+    await effect.update({ disabled: !effect.data.disabled });
+    Hooks.callAll("forceUpdateTokenActionHUD");
+  }
+
+  async toggleCondition(event, tokenId, effectId) {
+    const token = super.getToken(tokenId);
+    const isRightClick = this.isRightClick(event);
+    if (
+      effectId.includes("combat-utility-belt.") &&
+      game.cub &&
+      !isRightClick
+    ) {
+      const cubCondition = this.findCondition(effectId)?.label;
+      if (!cubCondition) return;
+
+      game.cub.hasCondition(cubCondition, token)
+        ? await game.cub.removeCondition(cubCondition, token)
+        : await game.cub.addCondition(cubCondition, token);
+    } else {
+      const condition = this.findCondition(effectId);
+      if (!condition) return;
+
+      isRightClick
+        ? await token.toggleEffect(condition, {overlay : true})
+        : await token.toggleEffect(condition);
+    }
+
+    Hooks.callAll("forceUpdateTokenActionHUD");
+  }
+
+  findCondition(id) {
+    return CONFIG.statusEffects.find((effect) => effect.id === id);
+  }
+
+  _getDocumentData(entity) {
+    return entity.data.data ?? entity.data;
+  }
+}

--- a/scripts/settings/dnd4e-settings.js
+++ b/scripts/settings/dnd4e-settings.js
@@ -1,0 +1,65 @@
+export function register(appName, updateFunc) {
+  game.settings.register(appName, "abbreviateSkills", {
+    name: game.i18n.localize(
+      "tokenactionhud.settings.dnd5e.abbreviateSkills.name"
+    ),
+    hint: game.i18n.localize(
+      "tokenactionhud.settings.dnd5e.abbreviateSkills.hint"
+    ),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: (value) => {
+      updateFunc(value);
+    },
+  });
+
+  game.settings.register(appName, "showConditionsCategory", {
+    name: game.i18n.localize(
+        "tokenactionhud.settings.dnd5e.showConditionsCategory.name"
+    ),
+    hint: game.i18n.localize(
+        "tokenactionhud.settings.dnd5e.showConditionsCategory.hint"
+    ),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: true,
+    onChange: (value) => {
+      updateFunc(value);
+    },
+  });
+
+  game.settings.register(appName, "hideUsedPowers", {
+    name: game.i18n.localize(
+        "tokenactionhud.settings.dnd4e.hideUsedPowers.name"
+    ),
+    hint: game.i18n.localize(
+        "tokenactionhud.settings.dnd4e.hideUsedPowers.hint"
+    ),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: (value) => {
+      updateFunc(value);
+    },
+  });
+
+  game.settings.register(appName, "forcePowerColours", {
+    name: game.i18n.localize(
+        "tokenactionhud.settings.dnd4e.forcePowerColours.name"
+    ),
+    hint: game.i18n.localize(
+        "tokenactionhud.settings.dnd4e.forcePowerColours.hint"
+    ),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: (value) => {
+      updateFunc(value);
+    },
+  });
+}


### PR DESCRIPTION
Support for the 4E system https://github.com/EndlesNights/dnd4eBeta 

This should be a fully functional PR, there are one or 2 features that will not work until a PR for the 4E system is merged into release.  

Supports Skill Checks, Ability Checks, Saving Throws, Power Use, Conditions and Features.  No support for Effects or Inventory.

As the 4E system was a fork of the 5E system I was able to use the 5E system as a template and there is a lot of similarity between the code.  