### PR TITLE
4E Bugfixes:

### DIFF
--- a/scripts/actions/dnd4e/dnd4e-actions.js
+++ b/scripts/actions/dnd4e/dnd4e-actions.js
@@ -152,8 +152,14 @@ export class ActionHandlerDnD4e extends ActionHandler {
         let result = this.initializeEmptyCategory("Powers");
         result.name = this.i18n("DND4EBETA.Powers");
 
+        // powerGroupType is not initalised by default
+        let groupType = this._getDocumentData(actor).powerGroupTypes
+        if (!groupType) {
+            actor.data.data.powerGroupTypes = "usage"
+            groupType = "usage"
+        }
         const goupings = actor.sheet._generatePowerGroups()
-        const groupType = this._getDocumentData(actor).powerGroupTypes
+
         let groupField = "useType"
 
         switch (groupType) {
@@ -182,6 +188,12 @@ export class ActionHandlerDnD4e extends ActionHandler {
                 actor.sheet._checkPowerAvailable(power.data)
                 const data = this._getDocumentData(power)
                 return data.useType === "recharge" || !data.notAvailable
+            })
+        }
+        else {
+            // need to poke this to force the available boolean correctly for recharge powers
+            powers.forEach((power) => {
+                actor.sheet._checkPowerAvailable(power.data)
             })
         }
 

--- a/scripts/rollHandlers/dnd4e/dnd4e-base.js
+++ b/scripts/rollHandlers/dnd4e/dnd4e-base.js
@@ -75,7 +75,15 @@ export class RollHandlerBaseDnD4e extends RollHandler {
   rollItemMacro(event, tokenId, itemId) {
     let actor = super.getActor(tokenId);
     let item = super.getItem(actor, itemId);
-    return item.roll()
+
+    if (this.needsRecharge(actor, item)) {
+      const event = Object.assign({}, this.emptyEvent)
+      event.currentTarget = { closest : (str) => {return {dataset : { itemId : itemId}}} };
+      actor.sheet._onItemRecharge(event)
+      return;
+    }
+
+    return actor.usePower(item)
   }
 
   rollPowerMacro(event, tokenId, itemId) {


### PR DESCRIPTION
If not hiding used powers recharge rolls were not triggering because of how the sheet calculates that the power needs recharging

Because of how power grouping is stored it is possible for all powers to vanish on monsters, this can be worked around by changing the grouping in the character sheet.

Non urgent