### PR TITLE
Better handling of better rolls2 for SWADE rolls

### DIFF
--- a/scripts/rollHandlers/swade/swade-br2sw.js
+++ b/scripts/rollHandlers/swade/swade-br2sw.js
@@ -68,13 +68,13 @@ export class RollHandlerBR2SWSwade extends RollHandler {
       game.brsw
         .create_item_card_from_id(tokenId, actor.id, actionId)
         .then((message) => {
-          game.brsw.roll_item(message, "", false);
+          game.brsw.roll_item(message, $(message.data.content), false);
         });
     } else if (behavior === "trait_damage") {
       game.brsw
         .create_item_card_from_id(tokenId, actor.id, actionId)
         .then((message) => {
-          game.brsw.roll_item(message, "", false, true);
+          game.brsw.roll_item(message, $(message.data.content), false, true);
         });
     } else if (behavior === "system") {
       game.swade.rollItemMacro(actor.items.get(actionId).name);
@@ -151,7 +151,7 @@ export class RollHandlerBR2SWSwade extends RollHandler {
       game.brsw
         .create_attribute_card_from_id(tokenId, actor.id, actionId)
         .then((message) => {
-          game.brsw.roll_attribute(message, "", false);
+          game.brsw.roll_attribute(message, $(message.data.content), false);
         });
     } else if (behavior === "system") {
       actor.rollAttribute(actionId);
@@ -177,7 +177,7 @@ export class RollHandlerBR2SWSwade extends RollHandler {
       game.brsw
         .create_skill_card_from_id(tokenId, actor.id, actionId)
         .then((message) => {
-          game.brsw.roll_skill(message, "", false);
+          game.brsw.roll_skill(message, $(message.data.content), false);
         });
     } else if (behavior === "system") {
       game.swade.rollItemMacro(actor.items.get(actionId).name);


### PR DESCRIPTION
In SWADE, when using better rolls 2,  pass the default html content from  the message, to the roll functions, so it deducts ammo, processes edges and hindrances, etc, etc...

There are a couple of possible br2 rolls, that are usually selected in setting or using a modifier key (that you have probably deduced by the code). 

Most people show the card, make adjustment there and click roll. For those people Token Action Hud works nicely.

But some people make direct rolls (i.e. clicking shows the card and makes the roll(s)). Lots of things (if ammo is deducted, modifiers, state changes, etc...) are not automatically applied but shown in the card to be enable or not by the user. The roller needs the card html to check if they are enabled or not, so passing an empty string means that they will never be applied.

This solution is somewhat expensive as it jquerifies message.content, but it enables tons of functionality and is probably fast enough to be not noticeable.