### PR TITLE
DND 4E: Updated conditions to pull in from main config

### DIFF
--- a/scripts/actions/dnd4e/dnd4e-actions.js
+++ b/scripts/actions/dnd4e/dnd4e-actions.js
@@ -558,7 +558,7 @@ export class ActionHandlerDnD4e extends ActionHandler {
         const category = this.initializeEmptyCategory("conditions");
         const macroType = "condition";
 
-        const availableConditions = game.dnd4eBeta.config.statusEffect.filter(
+        const availableConditions = CONFIG.statusEffects.filter(
             (condition) => condition.id !== ""
         );
         const actors = canvas.tokens.controlled
@@ -602,7 +602,7 @@ export class ActionHandlerDnD4e extends ActionHandler {
     _addConditionsSubcategory(actor, tokenId, category) {
         const macroType = "condition";
 
-        const availableConditions = game.dnd4eBeta.config.statusEffect.filter(
+        const availableConditions = CONFIG.statusEffects.filter(
             (condition) => condition.id !== ""
         );
 


### PR DESCRIPTION
Action handler was using 4e's specific config object, not the main game one.  This should aid with CUB compatibility.

No rush - main functionality is fine, this is for hopefully better module integration.  