### PR TITLE
Update for Earthdawn 4E

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -72,6 +72,7 @@
     "gear": "Ausrüstung",
     "get": "Get",
     "gm": "GM",
+    "general": "Allgemein",
     "grit": "Grit",
     "handlerNotFound": "not found, reverting to core roller.",
     "hase": "HASE",

--- a/lang/en.json
+++ b/lang/en.json
@@ -79,6 +79,7 @@
     "gear": "Gear",
     "get": "Get",
     "gm": "GM",
+    "general": "General",
     "grit": "Grit",
     "handlerNotFound": "not found, reverting to core roller.",
     "hase": "HASE",

--- a/scripts/actions/ed4e/ed4e-actions.js
+++ b/scripts/actions/ed4e/ed4e-actions.js
@@ -376,19 +376,7 @@ export class ActionHandlerED4e extends ActionHandler {
             .sort((a,b) => a.name.localeCompare(b.name));
         let weaponsCat = this.initializeEmptySubcategory();
         weaponsCat.actions = weaponActions;
-        this._combineSubcategoryWithCategory(result, this.i18n("earthdawn.w.weapons"), weaponsCat);
-
-        // matrices
-        if (matricesCat.length > 0) {
-            let matrixSub = matricesCat.subcategories[0];
-            this._combineSubcategoryWithCategory(result, matrixSub.name, matrixSub)
-        }
-
-        // favorites
-        if (favoriteCat.length > 0) {
-            let favoriteSub = favoriteCat.subcategories[0];
-            this._combineSubcategoryWithCategory(result, favoriteSub.name, favoriteSub)
-        }
+        this._combineSubcategoryWithCategory(result, `${this.i18n("earthdawn.w.weapons")} ${this.i18n("earthdawn.a.attack")}`, weaponsCat);
 
         // tactics
         if (statusCat.length > 0) {
@@ -397,8 +385,25 @@ export class ActionHandlerED4e extends ActionHandler {
         }
 
         // actions
-
-
+        let actionsCat = this.initializeEmptySubcategory();
+        actionsCat.actions = [
+            {
+                name: this.i18n("earthdawn.t.takeDamage"),
+                id: null,
+                encodedValue: ["takedamage", token.id, "takedamage"].join(this.delimiter),
+            },
+            {
+                name: this.i18n("earthdawn.c.combatOptionsKnockdownTest"),
+                id: null,
+                encodedValue: ["knockdowntest", token.id, "knockdowntest"].join(this.delimiter),
+            },
+            {
+                name: this.i18n("earthdawn.c.combatOptionsJumpUp"),
+                id: null,
+                encodedValue: ["jumpup", token.id, "jumpup"].join(this.delimiter),
+            },
+        ];
+        this._combineSubcategoryWithCategory(result, this.i18n("earthdawn.a.actions"), actionsCat);
 
         return result;
     }

--- a/scripts/actions/ed4e/ed4e-actions.js
+++ b/scripts/actions/ed4e/ed4e-actions.js
@@ -294,22 +294,30 @@ export class ActionHandlerED4e extends ActionHandler {
         const macroType = "toggle";
 
         const tacticsProperties = [
-            "tactics.aggressive",
-            "tactics.defensive",
-            "tactics.harried",
-            "tactics.knockeddown"
+            "earthdawn.c.combatOptionsAggressive",
+            "earthdawn.c.combatOptionsDefensive",
+            "earthdawn.c.combatModifierHarried",
+            "earthdawn.c.combatModifierKnockedDown"
         ]
 
         const systemProperties = [
-            "usekarma"
+            "earthdawn.u.useKarma"
         ]
+
+        const mapPropToActionID = {
+            "earthdawn.c.combatOptionsAggressive": "tactics.aggressive",
+            "earthdawn.c.combatOptionsDefensive": "tactics.defensive",
+            "earthdawn.c.combatModifierHarried": "tactics.harried",
+            "earthdawn.c.combatModifierKnockedDown": "tactics.knockeddown",
+            "earthdawn.u.useKarma": "usekarma"
+        }
 
         let tacticsActions = tacticsProperties.map( e => {
                 return {
-                    name: e, // localize in system
+                    name: this.i18n(e), // localize in system
                     id: null,
-                    encodedValue: [macroType, token.id, e ].join(this.delimiter),
-                    cssClass: actor.data.data.tactics[e.split(".")[1]] === true ? 'active' : ''
+                    encodedValue: [macroType, token.id, mapPropToActionID[e]].join(this.delimiter),
+                    cssClass: actor.data.data.tactics[mapPropToActionID[e].split(".")[1]] === true ? 'active' : ''
                 }
             }
         ).filter(s => !!s) // filter out nulls
@@ -320,10 +328,10 @@ export class ActionHandlerED4e extends ActionHandler {
 
         let systemActions = systemProperties.map( e => {
                 return {
-                    name: e, // localize in system
+                    name: this.i18n(e), // localize in system
                     id: null,
-                    encodedValue: [macroType, token.id, e ].join(this.delimiter),
-                    cssClass: actor.data.data[e].toLowerCase() === "true" ? 'active' : ''
+                    encodedValue: [macroType, token.id, mapPropToActionID[e]].join(this.delimiter),
+                    cssClass: actor.data.data["usekarma"] === "true" ? 'active' : ''
                 }
             }
         ).filter(s => !!s) // filter out nulls

--- a/scripts/actions/ed4e/ed4e-actions.js
+++ b/scripts/actions/ed4e/ed4e-actions.js
@@ -38,6 +38,7 @@ export class ActionHandlerED4e extends ActionHandler {
     }
 
     _buildCategories(token) {
+        let generalCat = this._buildGeneralCategory(token);
         let favoriteCat = this._buildFavoritesCategory(token);
         let talentCat = this._buildTalentsCategory(token);
         let matrixCat = this._buildMatrixCategory(token);
@@ -46,6 +47,7 @@ export class ActionHandlerED4e extends ActionHandler {
         let statCat = this._buildStatusCategory(token);
         let combatCat = this._buildCombatCategory(token, itemsCat, [], favoriteCat, statCat);
         return [
+            generalCat,
             favoriteCat,
             talentCat,
             matrixCat,
@@ -59,6 +61,61 @@ export class ActionHandlerED4e extends ActionHandler {
             //this._buildPowersCategory(token),
 
         ]
+    }
+
+    _buildGeneralCategory(token) {
+        if (!settings.get("showGeneral")) return;
+
+        const actor = token.actor;
+        if (['pc', 'npc'].indexOf(actor.data.type) < 0) return;
+
+        const attributeProperties = [
+            "earthdawn.d.dexterity",
+            "earthdawn.s.strength",
+            "earthdawn.t.toughness",
+            "earthdawn.p.perception",
+            "earthdawn.w.willpower",
+            "earthdawn.c.charisma",
+        ]
+
+        let attributeActions = attributeProperties.map( e => {
+                return {
+                    name: this.i18n(e), // localize in system
+                    id: null,
+                    encodedValue: ["attribute", token.id, e].join(this.delimiter),
+                }
+            }
+        ).filter(s => !!s); // filter out nulls
+
+        let attributeCat = this.initializeEmptySubcategory();
+        attributeCat.actions = attributeActions;
+
+        let otherCat = this.initializeEmptySubcategory();
+        otherCat.actions = [
+            {
+                name: this.i18n("earthdawn.r.recovery"),
+                id: null,
+                encodedValue: ["recovery", token.id, "recovery"].join(this.delimiter),
+            },
+            {
+                name: this.i18n("earthdawn.n.newDay"),
+                id: null,
+                encodedValue: ["newday", token.id, "newday"].join(this.delimiter),
+            },
+            {
+                name: this.i18n("earthdawn.h.halfMagic"),
+                id: null,
+                encodedValue: ["halfmagic", token.id, "halfmagic"].join(this.delimiter),
+            }
+        ];
+
+        let result = this.initializeEmptyCategory('general');
+        result.name = this.i18n("tokenactionhud.general");
+
+        this._combineSubcategoryWithCategory(result, this.i18n("earthdawn.a.attributes"), attributeCat);
+        this._combineSubcategoryWithCategory(result, this.i18n("earthdawn.o.other"), otherCat);
+
+        return result;
     }
 
     _buildFavoritesCategory(token) {

--- a/scripts/actions/ed4e/ed4e-actions.js
+++ b/scripts/actions/ed4e/ed4e-actions.js
@@ -200,7 +200,10 @@ export class ActionHandlerED4e extends ActionHandler {
     }
 
     _buildMatrixCategory(token) {
-        if (!settings.get("showMatrices")) return;
+        if (
+            (!settings.get("showMatrices"))
+            || !(token.actor.items.find(e => e.type==='spellmatrix'))
+        ) return;
 
         const actor = token.actor;
         if (['pc', 'npc'].indexOf(actor.data.type) < 0) return;

--- a/scripts/actions/ed4e/ed4e-actions.js
+++ b/scripts/actions/ed4e/ed4e-actions.js
@@ -53,7 +53,6 @@ export class ActionHandlerED4e extends ActionHandler {
             matrixCat,
             skillCat,
             itemsCat,
-            // this._buildAttributesCategory(token),
             // this._buildEffectsCategory(token),
             statCat,
             combatCat
@@ -200,25 +199,49 @@ export class ActionHandlerED4e extends ActionHandler {
 
         let result = this.initializeEmptyCategory('matrix');
         result.name = this.i18n("earthdawn.m.matrixes");
-        let macroType = 'matrix';
 
-        let spellActions = matrices.map(e => {
+        matrices.forEach(e => {
             try {
+                let matrixSubCategory = this.initializeEmptySubcategory();
                 let matrixId = e.id;
-                let name = e.data.data.currentspell;
-                let encodedValue = [macroType, token.id, matrixId].join(this.delimiter);
-                return {name: name, id: matrixId, encodedValue: encodedValue};
+
+                console.log(`${e.name}\n${e.data.data.currentspell}`)
+
+                matrixSubCategory.actions = [
+                    {
+                        name: this.i18n("earthdawn.a.attune"),
+                        id: matrixId,
+                        encodedValue: ['matrixAttune', token.id, matrixId].join(this.delimiter),
+                    },
+                    {
+                        name: this.i18n("earthdawn.m.matrixWeaveRed"),
+                        id: matrixId,
+                        encodedValue: ['matrixWeave', token.id, matrixId].join(this.delimiter),
+                    },
+                    {
+                        name: this.i18n("earthdawn.m.matrixCastRed"),
+                        id: matrixId,
+                        encodedValue: ['matrixCast', token.id, matrixId].join(this.delimiter),
+                    },
+                    {
+                        name: this.i18n("earthdawn.m.matrixClearRed"),
+                        id: matrixId,
+                        encodedValue: ['matrixClear', token.id, matrixId].join(this.delimiter),
+                    },
+                ]
+
+                let name_subcat = e.data.data.currentspell ? `${e.data.data.currentspell} (${e.data.data.totalthreads}/${e.data.data.threadsrequired})` : e.name;
+
+                this._combineSubcategoryWithCategory(
+                    result,
+                    name_subcat,
+                    matrixSubCategory
+                );
             } catch (error) {
                 Logger.error(e);
-                return;
+                throw error;
             }
-        }).filter(s => !!s) // filter out nulls
-            .sort((a,b) => a.name.localeCompare(b.name));
-        let spellsCategory = this.initializeEmptySubcategory();
-        spellsCategory.actions = spellActions;
-
-        let spellsTitle = this.i18n("earthdawn.s.spells");
-        this._combineSubcategoryWithCategory(result, spellsTitle, spellsCategory);
+        });
 
         return result;
     }
@@ -299,7 +322,7 @@ export class ActionHandlerED4e extends ActionHandler {
     }
 
     _buildItem(tokenId, actor, macroType, item) {
-        const itemData = this._getEntityData(item);
+        //const itemData = this._getEntityData(item);
         const itemId = item.id ?? item._id;
         let encodedValue = [macroType, tokenId, itemId].join(this.delimiter);
         let img = this._getImage(item);

--- a/scripts/rollHandlers/ed4e/ed4e-base.js
+++ b/scripts/rollHandlers/ed4e/ed4e-base.js
@@ -79,6 +79,15 @@ export class RollHandlerBaseED4e extends RollHandler {
             case 'weaponAttack':
                 actor.rollPrep({weaponID: actionId, rolltype: 'attack'});
                 break;
+            case 'takedamage':
+                this.takeDamage(actor);
+                break;
+            case 'knockdowntest':
+                actor.knockdownTest({});
+                break;
+            case 'jumpup':
+                actor.jumpUpTest();
+                break;
         }
     }
 
@@ -170,5 +179,45 @@ export class RollHandlerBaseED4e extends RollHandler {
         } else {
             actor.items.get(actionId).sheet.render(true);
         }
+    }
+
+    async takeDamage(actor) {
+        let inputs = await new Promise((resolve) => {
+            new Dialog({
+                title: this.i18n('earthdawn.t.takeDamage'),
+                content: `
+          <div style="float: left">
+              <label>${this.i18n('earthdawn.d.damage')}: </label>
+              <input id="damage_box" value=0 autofocus/>
+          </div>
+          <div>
+              <label>${this.i18n('earthdawn.t.type')}: </label>
+              <select id="type_box">
+                <option value="physical">Physical</option>
+                <option value="mystic">Mystic</option>
+              </select>
+          </div>
+          <div>
+            <label>${this.i18n('earthdawn.i.ignoreArmor')}?</label>
+            <input type="checkbox" id="ignore_box"/>
+          </div>`,
+                buttons: {
+                    ok: {
+                        label: this.i18n('earthdawn.o.ok'),
+                        callback: (html) => {
+                            resolve({
+                                damage: html.find('#damage_box').val(),
+                                type: html.find('#type_box').val(),
+                                ignore: html.find('#ignore_box:checked'),
+                            });
+                        },
+                    },
+                },
+                default: 'ok',
+            }).render(true);
+        });
+
+        inputs.ignorearmor = inputs.ignore.length > 0;
+        await actor.takeDamage(inputs);
     }
 }

--- a/scripts/rollHandlers/ed4e/ed4e-base.js
+++ b/scripts/rollHandlers/ed4e/ed4e-base.js
@@ -39,6 +39,13 @@ export class RollHandlerBaseED4e extends RollHandler {
             case 'talent':
                 this.rollTalentMacro(event, tokenId, actionId);
                 break;
+            case 'attack':
+                // fall through
+            case 'power':
+                // fall through
+            case 'maneuver':
+                this.handleCreatureActionMacro(event, tokenId, actionId);
+                break;
             case 'inventory':
                 this.rollInventoryMacro(event, tokenId, actionId);
                 break;
@@ -122,5 +129,30 @@ export class RollHandlerBaseED4e extends RollHandler {
         if (val.toLowerCase().includes("true")) return "false";
         if (val.toLowerCase().includes("false")) return "true";
         return "false";
+    }
+
+    handleCreatureActionMacro(event, tokenId, actionId) {
+        const actor = super.getActor(tokenId);
+        const item = actor.items.get(actionId);
+
+        if (item.data.data.attackstep !== 0) {
+            const modifier = 0;
+            const strain = item.data.data.strain ? item.data.data.strain : 0;
+            const karma = 0;
+
+            let type = (item.data.data.powerType === "Attack") ? "attack" : (item.data.data.attackstep > 0) ? "test" : "";
+            const parameters = {
+                itemID: actionId,
+                steps: item.data.data.attackstep,
+                talent: item.name,
+                strain: strain,
+                type: type,
+                karma: karma,
+                modifier: modifier,
+            };
+            actor.NPCtest(parameters);
+        } else {
+            actor.items.get(actionId).sheet.render(true);
+        }
     }
 }

--- a/scripts/rollHandlers/ed4e/ed4e-base.js
+++ b/scripts/rollHandlers/ed4e/ed4e-base.js
@@ -43,7 +43,25 @@ export class RollHandlerBaseED4e extends RollHandler {
                 break;
             case 'toggle':
                 this.toggleDataProperty(event, tokenId, actionId);
+                break;
+            case 'attribute':
+                this.rollAttributeMacro(event, tokenId, actionId);
+                break;
+            case 'recovery':
+                super.getActor(tokenId).recoveryTest();
+                break;
+            case 'newday':
+                super.getActor(tokenId).newDay();
+                break;
+            case 'halfmagic':
+                super.getActor(tokenId).halfMagic();
+                break;
         }
+    }
+
+    rollAttributeMacro(event, tokenId, actionId) {
+        const actor = super.getActor(tokenId);
+        actor.rollPrep({ attribute: `${actionId.split('.').slice(-1)}Step`, name: actionId });
     }
 
     rollTalentMacro(event, tokenId, actionId) {

--- a/scripts/rollHandlers/ed4e/ed4e-base.js
+++ b/scripts/rollHandlers/ed4e/ed4e-base.js
@@ -32,6 +32,7 @@ export class RollHandlerBaseED4e extends RollHandler {
     }
 
     async _handleMacros(event, macroType, tokenId, actionId) {
+        let actor = super.getActor(tokenId);
         switch (macroType) {
             case 'skill':
                 // fall through
@@ -48,13 +49,25 @@ export class RollHandlerBaseED4e extends RollHandler {
                 this.rollAttributeMacro(event, tokenId, actionId);
                 break;
             case 'recovery':
-                super.getActor(tokenId).recoveryTest();
+                actor.recoveryTest();
                 break;
             case 'newday':
-                super.getActor(tokenId).newDay();
+                actor.newDay();
                 break;
             case 'halfmagic':
-                super.getActor(tokenId).halfMagic();
+                actor.halfMagic();
+                break;
+            case 'matrixAttune':
+                actor.attuneMatrix(actor.items.get(actionId));
+                break;
+            case 'matrixWeave':
+                actor.weaveThread(actor.items.get(actionId));
+                break;
+            case 'matrixCast':
+                actor.castSpell(actor.items.get(actionId));
+                break;
+            case 'matrixClear':
+                actor.clearMatrix(actor.items.get(actionId));
                 break;
         }
     }

--- a/scripts/rollHandlers/ed4e/ed4e-base.js
+++ b/scripts/rollHandlers/ed4e/ed4e-base.js
@@ -35,14 +35,14 @@ export class RollHandlerBaseED4e extends RollHandler {
         let actor = super.getActor(tokenId);
         switch (macroType) {
             case 'skill':
-                // fall through
+            // fall through
             case 'talent':
                 this.rollTalentMacro(event, tokenId, actionId);
                 break;
             case 'attack':
-                // fall through
+            // fall through
             case 'power':
-                // fall through
+            // fall through
             case 'maneuver':
                 this.handleCreatureActionMacro(event, tokenId, actionId);
                 break;
@@ -76,6 +76,9 @@ export class RollHandlerBaseED4e extends RollHandler {
             case 'matrixClear':
                 actor.clearMatrix(actor.items.get(actionId));
                 break;
+            case 'weaponAttack':
+                actor.rollPrep({weaponID: actionId, rolltype: 'attack'});
+                break;
         }
     }
 
@@ -92,10 +95,10 @@ export class RollHandlerBaseED4e extends RollHandler {
     rollInventoryMacro(event, tokenId, actionId) {
         const actor = super.getActor(tokenId);
         const item = actor.items.get(actionId);
-        if (item.type === 'weapon') {
-            actor.rollPrep({weaponID: actionId, rolltype: 'attack'});
-        } else if (item.type === 'equipment') {
-            ui.notifications.info("This is not clickable, sorry")
+        if (item.type === 'equipment') {
+            item.sheet.render(true);
+        } else if (['weapon', 'armor', 'shield'].indexOf(item.type) >= 0) {
+            this.toggleItemWornProperty(event, tokenId, actionId);
         } else {
             //problem
             Logger.error(item.type, " is not a valid actionId for rolling an inventory item")
@@ -123,6 +126,19 @@ export class RollHandlerBaseED4e extends RollHandler {
                 }
             })
         }
+    }
+
+    toggleItemWornProperty(event, tokenId, actionId) {
+        const actor = super.getActor(tokenId);
+        const item = actor.items.get(actionId);
+        const currentValue = item.data.data['worn'];
+        const valueType = typeof currentValue;
+        let newValue = valueType === "string" ? this._toggleBooleanString(currentValue) : !currentValue;
+        item.update({
+            data: {
+                worn: newValue
+            }
+        })
     }
 
     _toggleBooleanString(val) {

--- a/scripts/rollHandlers/ed4e/ed4e-base.js
+++ b/scripts/rollHandlers/ed4e/ed4e-base.js
@@ -2,6 +2,9 @@ import { RollHandler } from '../rollHandler.js';
 import {Logger} from "../../logger.js";
 
 export class RollHandlerBaseED4e extends RollHandler {
+
+
+
     constructor() {
         super();
     }

--- a/scripts/settings/ed4e-settings.js
+++ b/scripts/settings/ed4e-settings.js
@@ -1,5 +1,15 @@
 export function register(appName, updateFunc) {
 
+    game.settings.register(appName, 'showGeneral', {
+        name: "Show General",
+        hint: "Display category for general rolls like Attributes, Half-Magic or Recovery",
+        scope: "client",
+        config: true,
+        type: Boolean,
+        default: true,
+        onChange: value => {updateFunc(value);}
+    });
+
     game.settings.register(appName, 'showFavorites', {
         name: "Show Favorites",
         hint: "Display category for items marked as favorites",


### PR DESCRIPTION
The categories and functionalities for the Earthdawn system have been extended and modified.
Here's a list of what changed:

- missing translations were added (e.g. for the "Use Karma" option or the combat states
- added category "General": includes attribute rolls, recovery rolls, half-magic rolls, and the "New Day" functionality
- added functionality to category "Matrices": lists all available matrices and the available options. If a matrix is attuned, it shows the spell name and the active/required threads of that spell. Otherwise the name of the matrix is shown.
- added support for actor type "creature": categories are built analogous to N/PCs
- the category "Matrices" now is automatically disabled if the actor does not own any items of type "spellmatrix"
- remodeled category "Inventory": now shows also armors and shields. Clicking on these or a weapons toggles their equipped status. Clicking on equipment displays the item sheet.
- remodeled category "Combat": shows weapons that are equipped; if clicked, an attack sequence with the respective weapon is initiated. Added combat actions (take damage, knockdown test, jump up). Moved combat states to this category.
- removed and transfered category "Status & Toggles": combat states are moved category "Combat". system options are moved to category "General". The original category is removed.
