### PR TITLE
Opend6 Space: extend vehicle actions

### DIFF
--- a/scripts/actions/od6s/od6s-actions.js
+++ b/scripts/actions/od6s/od6s-actions.js
@@ -50,6 +50,7 @@ export class ActionHandlerOD6S extends ActionHandler {
                 game.i18n.localize("OD6S.ATTRIBUTES"),
                 attributeCategory
             );
+
             this._combineCategoryWithList(
                 result,
                 game.i18n.localize("OD6S.SKILLS"),
@@ -58,11 +59,13 @@ export class ActionHandlerOD6S extends ActionHandler {
         }
 
         if (actor.type === 'vehicle' || actor.type === 'starship') {
-            console.log(actor);
-            if (actor.data.data.crewmembers.length > 0) {
-                for (let i in actor.data.data.crewmembers) {
-                    let actor = game.od6s.getActorFromUuid(i);
-                    console.log(actor);
+            if(game.user.isGM) {
+                if (actor.data.data.crewmembers.length > 0) {
+                    for (let i of actor.data.data.crewmembers) {
+                        let crewMember = await game.od6s.getActorFromUuid(i.uuid);
+                        let category = this._buildVehicleCategory(crewMember, result.tokenId);
+                        this._combineCategoryWithList(result, crewMember.name, category);
+                    }
                 }
             }
         }

--- a/scripts/actions/od6s/od6s-actions.js
+++ b/scripts/actions/od6s/od6s-actions.js
@@ -16,46 +16,62 @@ export class ActionHandlerOD6S extends ActionHandler {
         let actor = token.actor;
 
         if (!actor) return result;
-        if (actor.type === 'starship' || actor.type === 'vehicle') return result;
+        if (actor.type === 'container') return result;
 
         result.actorId = actor.id;
 
-        let combatCategory = this._buildCombatActionsCategory(actor, result.tokenId);
+        if (actor.type !== 'vehicle' && actor.type !== 'starship') {
+            let combatCategory = this._buildCombatActionsCategory(actor, result.tokenId);
 
-        let vehicleCategory = this._buildVehicleCategory(actor, result.tokenId);
+            let vehicleCategory = this._buildVehicleCategory(actor, result.tokenId);
 
-        let attributeCategory = this._buildAttributesCategory(
-            actor,
-            result.tokenId,
-            "attributes"
-        );
+            let attributeCategory = this._buildAttributesCategory(
+                actor,
+                result.tokenId,
+                "attributes"
+            );
 
-        let skillCategory = this._buildSkillsCategory(actor, result.tokenId, "skills");
+            let skillCategory = this._buildSkillsCategory(actor, result.tokenId, "skills");
 
-        this._combineCategoryWithList(
-            result,
-            game.i18n.localize("OD6S.COMBAT"),
-            combatCategory
-        );
+            this._combineCategoryWithList(
+                result,
+                game.i18n.localize("OD6S.COMBAT"),
+                combatCategory
+            );
 
-        this._combineCategoryWithList(
-            result,
-            game.i18n.localize("OD6S.VEHICLE"),
-            vehicleCategory
-        )
+            this._combineCategoryWithList(
+                result,
+                game.i18n.localize("OD6S.VEHICLE"),
+                vehicleCategory
+            )
 
-        this._combineCategoryWithList(
-            result,
-            game.i18n.localize("OD6S.ATTRIBUTES"),
-            attributeCategory
-        );
-        this._combineCategoryWithList(
-            result,
-            game.i18n.localize("OD6S.SKILLS"),
-            skillCategory
-        );
+            this._combineCategoryWithList(
+                result,
+                game.i18n.localize("OD6S.ATTRIBUTES"),
+                attributeCategory
+            );
+            this._combineCategoryWithList(
+                result,
+                game.i18n.localize("OD6S.SKILLS"),
+                skillCategory
+            );
+        }
+
+        if (actor.type === 'vehicle' || actor.type === 'starship') {
+            console.log(actor);
+            if (actor.data.data.crewmembers.length > 0) {
+                for (let i in actor.data.data.crewmembers) {
+                    let actor = game.od6s.getActorFromUuid(i);
+                    console.log(actor);
+                }
+            }
+        }
 
         return result;
+    }
+
+    _buildCrewCategory(actor, tokenId) {
+        // Get all crew members
     }
 
     _buildCombatActionsCategory(actor, tokenId) {

--- a/scripts/rollHandlers/od6s/od6s-base.js
+++ b/scripts/rollHandlers/od6s/od6s-base.js
@@ -7,15 +7,17 @@ export class RollHandlerCoreOD6S extends RollHandler {
   }
 
   /** @override */
-  doHandleActionEvent(event, encodedValue) {
+  async doHandleActionEvent(event, encodedValue) {
     let payload = encodedValue.split("|");
     if (payload.length != 3) {
       super.throwInvalidValueErr();
     }
+
     let macroType = payload[0];
     let tokenId = payload[1];
     let actionId = payload[2];
-    let actor = super.getActor(tokenId);
+    let actor;
+    if(macroType !== 'crew') actor = super.getActor(tokenId);
     switch (macroType) {
       case "action":
         actor.rollAction(actionId);
@@ -31,6 +33,9 @@ export class RollHandlerCoreOD6S extends RollHandler {
         break;
       case "skill":
         this.rollItemMacro(event, actor, actionId);
+      case "crew":
+        actor = await game.od6s.getActorFromUuid(tokenId);
+        actor.rollAction(actionId);
       default:
         break;
     }


### PR DESCRIPTION
Allows a player or GM to roll crew actions via Token Action HUD when a vehicle token is selected.