### PR TITLE
GURPS V4 Support (Right mouse click on damage)

### DIFF
--- a/scripts/actions/gurps/gurps-actions.js
+++ b/scripts/actions/gurps/gurps-actions.js
@@ -109,7 +109,7 @@ export class ActionHandlerGURPS extends ActionHandler {
       }
       attributeCategory.actions.push({
         name: this.i18n("tokenactionhud.damage") + ' (' + e.damage + ')',
-        encodedValue: ["otf", tokenId, 'D:' + q + name + q].join(this.delimiter),
+        encodedValue: ["dam", tokenId, 'D:' + q + name + q].join(this.delimiter),
       }); 
 
       this._addNoteOTFs(attributeCategory, tokenId, name + ' ' + e.notes)
@@ -202,7 +202,7 @@ export class ActionHandlerGURPS extends ActionHandler {
         }); 
       attributeCategory.actions.push({
         name: this.i18n("tokenactionhud.damage") + ' (' + e.damage + ')',
-        encodedValue: ["otf", tokenId, 'D:' + q + name + q].join(this.delimiter),
+        encodedValue: ["dam", tokenId, 'D:' + q + name + q].join(this.delimiter),
       }); 
 
       this._addNoteOTFs(attributeCategory, tokenId, e.name + ' ' + e.notes)

--- a/scripts/rollHandlers/gurps/gurps-base.js
+++ b/scripts/rollHandlers/gurps/gurps-base.js
@@ -33,12 +33,26 @@ export class RollHandlerBaseGURPS extends RollHandler {
           case 'otf':
               this.executeOTF(event, actor, actionId)
               break
+          case 'dam':
+              this.executeOTF(event, actor, actionId, true)
+              break
       }
   }
 
-  async executeOTF(event, actor, otf) {
-    let saved = GURPS.LastActor
-    GURPS.SetLastActor(actor)
-    GURPS.executeOTF(otf).then(e => GURPS.SetLastActor(saved))
+  async executeOTF(event, actor, otf, rightClickDmg = false) {
+    if (rightClickDmg && this.isRightClick(event)) {
+      let action = GURPS.parselink(otf)
+      action.action.calcOnly = true
+      let formula = await GURPS.performAction(action.action, actor)
+      let ev = {... event}
+      ev.preventDefault = () => {}
+      ev.currentTarget = {... ev.currentTarget}
+      ev.currentTarget.innerText = formula
+      GURPS.resolveDamageRoll(ev, actor, formula, '', game.user.isGM, true)
+    } else {
+      let saved = GURPS.LastActor
+      GURPS.SetLastActor(actor)
+      GURPS.executeOTF(otf).then(e => GURPS.SetLastActor(saved))
+    }
   }
 }


### PR DESCRIPTION
In certain circumstances, the player may need to roll multiples of their current damage (for example, automatic weapons with a high rate of fire, etc.).

The GURPS system allows you to Right Mouse Click on any damage roll (on the charactersheet or chat log) to bring up the "Resolve Damage Roll" dialog.   

With this Pull Request, If the player right clicks on a damage element in the HUD, it will also bring up "Resolve Damage Roll" dialog.  

![image](https://user-images.githubusercontent.com/8931036/163881983-9e7f060d-a13b-4882-892c-7e7a629cceca.png)
