### PR TITLE
Update SW5e

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -431,6 +431,10 @@
           "hint": "If enabled, items are shown in the HUD even if they have no remaining charges.",
           "name": "Show empty items (includes items and powers)"
         },
+        "showItemsWithoutAction": {
+          "hint": "If enabled, Items that have no activation information will be added to the Inventory list",
+          "name": "Show Items without Activation costs"
+        },
         "showPowerInfo": {
           "hint": "If enabled, power component information, concentration, and ritual status will be noted next to the power name.",
           "name": "Display power information"

--- a/scripts/actions/sw5e/sw5e-actions.js
+++ b/scripts/actions/sw5e/sw5e-actions.js
@@ -235,17 +235,23 @@ export class ActionHandlerSW5e extends ActionHandler {
 
   /** @private */
   _getActiveEquipment(equipment) {
-    const activationTypes = Object.keys(
-      game.sw5e.config.abilityActivationTypes
-    ).filter((at) => at !== "none");
+    let activeEquipment = []
+    if (!settings.get("showItemsWithoutAction")) {
+      const activationTypes = Object.keys(
+        game.sw5e.config.abilityActivationTypes
+      ).filter((at) => at !== "none");
 
-    let activeEquipment = equipment.filter((e) => {
-      const equipmentData = this._getDocumentData(e);
-      let activation = equipmentData.activation;
-      if (!activation) return false;
+      activeEquipment = equipment.filter((e) => {
+        const equipmentData = this._getDocumentData(e);
+        let activation = equipmentData.activation;
+        if (!activation) return false;
 
-      return activationTypes.includes(equipmentData.activation.type);
-    });
+        return activationTypes.includes(equipmentData.activation.type);
+      });
+    }
+    else {
+      activeEquipment = equipment;
+    }
 
     return activeEquipment;
   }
@@ -429,7 +435,7 @@ export class ActionHandlerSW5e extends ActionHandler {
   /** @private */
   _buildFeaturesCategory(token) {
     let validFeats = this._filterLongerActions(
-      token.actor.data.items.filter((i) => i.type == "feat")
+      token.actor.data.items.filter((i) => ["feat", "classfeature", "deploymentfeature", "maneuver", "starshipfeature"].includes(i.type))
     );
     let sortedFeats = this._sortByItemSort(validFeats);
     return this._categoriseFeats(token.id, token.actor, sortedFeats);

--- a/scripts/settings/sw5e-settings.js
+++ b/scripts/settings/sw5e-settings.js
@@ -143,6 +143,22 @@ export function register(appName, updateFunc) {
     },
   });
 
+  game.settings.register(appName, "showItemsWithoutAction", {
+    name: game.i18n.localize(
+      "tokenactionhud.settings.sw5e.showItemsWithoutAction.name"
+    ),
+    hint: game.i18n.localize(
+      "tokenactionhud.settings.sw5e.showItemsWithoutAction.hint"
+    ),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: (value) => {
+      updateFunc(value);
+    },
+  });
+
   if (game.modules.get("character-actions-list-5e")?.active) {
     game.settings.register(appName, "useActionList", {
       name: game.i18n.localize("tokenactionhud.settings.useActionList.name"),


### PR DESCRIPTION
Bringing SW5e inline with DND5e changes (showing items without activation costs) and adding alternative feats (Class features, Deployment features, Maneuvers, and Starship features) to the features category.