### PR TITLE
Update GURPS support to add postures, and fixes raw HTML output

### DIFF
--- a/scripts/actions/gurps/gurps-actions.js
+++ b/scripts/actions/gurps/gurps-actions.js
@@ -52,7 +52,13 @@ export class ActionHandlerGURPS extends ActionHandler {
           this._maneuvers(actor, tokenId)
         );
   
-      if (settings.get("showHudTitle")) result.hudTitle = token.name;
+     this._combineCategoryWithList(
+      result,
+      this.i18n("GURPS.modifierPosture"),
+      this._postures(actor, tokenId)
+    );
+
+     if (settings.get("showHudTitle")) result.hudTitle = token.name;
   
       return result;
     }
@@ -134,7 +140,7 @@ export class ActionHandlerGURPS extends ActionHandler {
     let cnt = 0
     let columns = 0
     let result = this.initializeEmptyCategory(key);
-    GURPS.recurselist(actor.data[key], (e, k, d) => {
+    GURPS.recurselist(actor.system[key], (e, k, d) => {
       if (e.level > 0) {
         let attributeCategory = this.initializeEmptySubcategory();
         let q = '"'
@@ -166,9 +172,9 @@ export class ActionHandlerGURPS extends ActionHandler {
       GURPS.gurpslink(notes, false, true).forEach(a => {
         any = true
         attributeCategory.actions.push({
-          name: a.text, // a.text.match(/<span.*>(.*)<\/span>/)[1],
+          name: a.text, 
+          useRawHtmlName: true,
           encodedValue: ["otf", tokenId, a.action.orig].join(this.delimiter),
-          //cssClass: 'standalonggurpslink'
         }); 
       })
     return any
@@ -228,6 +234,22 @@ export class ActionHandlerGURPS extends ActionHandler {
       attributeCategory.actions.push({
         name: t,
         encodedValue: ["otf", tokenId, '/man ' + t].join(this.delimiter),
+        img: m.icon
+      }); 
+    })   
+    this._combineSubcategoryWithCategory(result, '', attributeCategory);
+    return result
+  }
+  
+  _postures(actor, tokenId) {
+    let result = this.initializeEmptyCategory("postures");
+    let attributeCategory = this.initializeEmptySubcategory();
+    let postures = {...GURPS.StatusEffect.getAllPostures()}
+    postures[GURPS.StatusEffectStanding] = { id: GURPS.StatusEffectStanding, label: GURPS.StatusEffectStandingLabel, icon: 'icons/svg/invisible.svg' }
+    Object.values(postures).forEach(m => {
+      attributeCategory.actions.push({
+        name: this.i18n(m.label),
+        encodedValue: ["otf", tokenId, '/st + ' + m.id].join(this.delimiter),
         img: m.icon
       }); 
     })   

--- a/templates/action.hbs
+++ b/templates/action.hbs
@@ -3,7 +3,11 @@
         {{~#if img~}}<div class="tah-img" style="background: url({{img}}) no-repeat center center; background-size:contain"></div>{{~/if~}}
         <span class="tah-action-name">
             {{~#if icon~}}<div class="tah-icon">{{{icon}}}</div>{{~/if~}}
-            {{name}}
+            {{~#if useRawHtmlName}}
+              {{{name}}}
+            {{~else~}}
+              {{name}}
+            {{~/if~}}
             {{~#if info1~}}<div class="tah-info1">{{info1}}</div>{{~/if~}}
             {{~#if info2~}}<div class="tah-info2">{{info2}}</div>{{~/if~}}
             {{~#if info3~}}<div class="tah-info3">{{info3}}</div>{{~/if~}}


### PR DESCRIPTION
Added support for Action names that contain RAW html.   The providing system sets the `useRawHtmlName` attribute to true.

Example:
```
        attributeCategory.actions.push({
          name: a.text, 
          useRawHtmlName: true,
          encodedValue: ["otf", tokenId, a.action.orig].join(this.delimiter),
        }); 
```