### PR TITLE
Fixes for pf2e effects category

### DIFF
--- a/scripts/actions/pf2e/pf2e-actions-pc.js
+++ b/scripts/actions/pf2e/pf2e-actions-pc.js
@@ -124,11 +124,6 @@ export class PcActionHandlerPf2e {
     );
     this.baseHandler._combineCategoryWithList(
       result,
-      this.i18n("tokenActionHud.effects"),
-      effects
-    );
-    this.baseHandler._combineCategoryWithList(
-      result,
       this.i18n("tokenActionHud.utility"),
       utilities
     );

--- a/scripts/actions/pf2e/pf2e-actions.js
+++ b/scripts/actions/pf2e/pf2e-actions.js
@@ -327,7 +327,7 @@ export class ActionHandlerPf2e extends ActionHandler {
 
     this._combineSubcategoryWithCategory(
       result,
-      this.i18n("tokenActionHud.weapons"),
+      this.i18n("tokenActionHud.effects"),
       effects
     );
 


### PR DESCRIPTION
Fixes the effects category in pf2e appearing twice. Also renames the subcategory from weapons to effects, which, while duplicating the main category name, seems more sensible.

State without this PR:
![effects](https://user-images.githubusercontent.com/9287484/199624208-5da24a82-35cf-4987-bd39-3adb90dab8bb.png)
