### PR TITLE
Fix ds4 item usage

### DIFF
--- a/scripts/rollHandlers/ds4/ds4-base.js
+++ b/scripts/rollHandlers/ds4/ds4-base.js
@@ -44,6 +44,6 @@ export class RollHandlerBaseDs4 extends RollHandler {
   async _rollItemMacro(event, tokenId, itemId) {
     const actor = super.getActor(tokenId);
     const item = super.getItem(actor, itemId);
-    return item.use();
+    return item.roll();
   }
 }


### PR DESCRIPTION
Testing the V10 development branch of the ds4 system, it turns out that the correct call is still "item.roll()" and not "item.use()". The latter leads to errors and non-function.